### PR TITLE
Fixing bug for ancestors endpoint

### DIFF
--- a/src/uuid_worker.py
+++ b/src/uuid_worker.py
@@ -668,9 +668,8 @@ class UUIDWorker:
         if isinstance(results, list) and (len(results) == 0):
             return Response("Could not find the target id or target id has no ancestors: " + app_id, 404)
 
-        #        rdict = self._convert_result_id_array(results, app_id)
-        results = self.modify_app_specific_uuid(results)
-        return json.dumps(results, indent=4, sort_keys=True, default=str)
+        rdict = self._convert_result_id_array(results, app_id)
+        return json.dumps(rdict, indent=4, sort_keys=True, default=str)
 
     def getFileIdInfo(self, fid):
         check_id = fid.strip()

--- a/src/uuid_worker.py
+++ b/src/uuid_worker.py
@@ -668,8 +668,7 @@ class UUIDWorker:
         if isinstance(results, list) and (len(results) == 0):
             return Response("Could not find the target id or target id has no ancestors: " + app_id, 404)
 
-        rdict = self._convert_result_id_array(results, app_id)
-        return json.dumps(rdict, indent=4, sort_keys=True, default=str)
+        return json.dumps(results, indent=4, sort_keys=True, default=str)
 
     def getFileIdInfo(self, fid):
         check_id = fid.strip()


### PR DESCRIPTION
Fixes a bug that was pointed out by @kburke when accessing the ancestors endpoint (e.g http://localhost:5001/9aa8ec786ba592a4db8a83432391b7fc/ancestors)