### PR TITLE
Tjmadonna/update pytest

### DIFF
--- a/src/requirements.dev.txt
+++ b/src/requirements.dev.txt
@@ -1,2 +1,2 @@
 # For testing
-pytest>=7.4.4,<8.0
+pytest>=9.0.3,<10.0


### PR DESCRIPTION
I updated `pytest` to version 9. All tests are passing. `pytest` is only installed for testing and isn't installed on production. No need to bump the API version because of this.